### PR TITLE
Gemfile to whitelist plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
Looks like GitHub is starting to actually run with `--safe`. My builds started failing a few weeks ago. This fixed them. 

Per http://jekyllrb.com/docs/plugins/

> GitHub Pages is powered by Jekyll. However, all Pages sites are generated using the --safe option to disable custom plugins for security reasons. Unfortunately, this means your plugins won’t work if you’re deploying to GitHub Pages.

Fix comes from https://github.com/github/pages-gem/pull/209