### PR TITLE
Add CSS for dashed lists

### DIFF
--- a/_sass/poole/_type.scss
+++ b/_sass/poole/_type.scss
@@ -129,4 +129,5 @@ ul > li:before {
   content: "—"; /* em dash */
   position: absolute;
   margin-left: -1.1em; 
+  font-weight: bold;
 }

--- a/_sass/poole/_type.scss
+++ b/_sass/poole/_type.scss
@@ -118,3 +118,15 @@ a[href^="#fnref:"] {
   font-size: 1.25rem;
   font-weight: 300;
 }
+
+/* Dashed un-ordered lists */
+ul {
+  list-style-type: none;
+  padding-left: 1em;
+}
+
+ul > li:before {
+  content: "—"; /* em dash */
+  position: absolute;
+  margin-left: -1.1em; 
+}

--- a/_sass/poole/_type.scss
+++ b/_sass/poole/_type.scss
@@ -122,7 +122,7 @@ a[href^="#fnref:"] {
 /* Dashed un-ordered lists */
 ul {
   list-style-type: none;
-  padding-left: 1em;
+  padding-left: 2em;
 }
 
 ul > li:before {
@@ -130,4 +130,20 @@ ul > li:before {
   position: absolute;
   margin-left: -1.1em; 
   font-weight: bold;
+}
+
+/* Bold numbers for numbered lists */
+ol > li {
+  margin: 0;
+  padding-left: 2em;
+  text-indent: -2em;
+  list-style-type: none;
+  counter-increment: item;
+}
+
+ol > li:before {
+  content: counter(item) ".";
+  font-weight: bold;
+  margin-left: -1.1em; 
+  padding-right: 0.5em;
 }


### PR DESCRIPTION
This uses `-` instead of `*` for bulleted lists.