### PR TITLE
enhancement: sub sample while matching case_id between collisions and parties

### DIFF
--- a/files/interview-prep/Interview Prep Python.ipynb
+++ b/files/interview-prep/Interview Prep Python.ipynb
@@ -47,7 +47,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "REDUCTION_FACTOR = 10"
+    "REDUCTION_FACTOR = 10 \n",
+    "RAND_REMAINDER=int(random.random()*REDUCTION_FACTOR) # a random number no larger than REDUCTION_FACTOR"
    ]
   },
   {
@@ -57,10 +58,12 @@
    "outputs": [],
    "source": [
     "collisions = pd.read_sql(\n",
-    "    f\"SELECT * FROM collisions WHERE ABS(RANDOM() % {REDUCTION_FACTOR}) = 0\", \n",
+    "    f\"SELECT * FROM collisions WHERE case_id%{REDUCTION_FACTOR} = {RAND_REMAINDER}\", \n",
     "    con, \n",
     "    parse_dates=[\"collision_date\"]\n",
-    ")"
+    ")\n",
+    "# the end of case_id values act as decent pseudo uniform random number between 0--REDUCTION_FACTOR \n",
+    "# select case_id values ending in RAND_REMAINDER"
    ]
   },
   {
@@ -69,7 +72,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parties = pd.read_sql(f\"SELECT * FROM parties WHERE ABS(RANDOM() % {REDUCTION_FACTOR}) = 0\", con)"
+    "# select by the same case_id values\n",
+    "parties = pd.read_sql(f\"SELECT * FROM parties WHERE case_id%{REDUCTION_FACTOR} = {RAND_REMAINDER}\", con)"
    ]
   },
   {

--- a/files/interview-prep/Interview Prep Python.ipynb
+++ b/files/interview-prep/Interview Prep Python.ipynb
@@ -7,7 +7,8 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import sqlite3"
+    "import sqlite3\n",
+    "import random"
    ]
   },
   {


### PR DESCRIPTION
I hope this is the right branch for PR. 
I avoid reading any full table into dataframe, since that would stall my laptop. I couldn't find a simple way to randomly select the same `case_id` on  two tables within SQL query. So I came up with a semi-random way of selecting `case_id` based on the trailing digits (which should be random enough). 
for issue https://github.com/agude/agude.github.io/issues/55