### PR TITLE
2 slight enhancements in SQL solution

### DIFF
--- a/files/interview-prep/Interview Prep Python.ipynb
+++ b/files/interview-prep/Interview Prep Python.ipynb
@@ -47,8 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "REDUCTION_FACTOR = 10 \n",
-    "RAND_REMAINDER=int(random.random()*REDUCTION_FACTOR) # a random number no larger than REDUCTION_FACTOR"
+    "REDUCTION_FACTOR = 10"
    ]
   },
   {
@@ -58,12 +57,10 @@
    "outputs": [],
    "source": [
     "collisions = pd.read_sql(\n",
-    "    f\"SELECT * FROM collisions WHERE case_id%{REDUCTION_FACTOR} = {RAND_REMAINDER}\", \n",
+    "    f\"SELECT * FROM collisions WHERE ABS(RANDOM() % {REDUCTION_FACTOR}) = 0\", \n",
     "    con, \n",
     "    parse_dates=[\"collision_date\"]\n",
-    ")\n",
-    "# the end of case_id values act as decent pseudo uniform random number between 0--REDUCTION_FACTOR \n",
-    "# select case_id values ending in RAND_REMAINDER"
+    ")"
    ]
   },
   {
@@ -72,8 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# select by the same case_id values\n",
-    "parties = pd.read_sql(f\"SELECT * FROM parties WHERE case_id%{REDUCTION_FACTOR} = {RAND_REMAINDER}\", con)"
+    "parties = pd.read_sql(f\"SELECT * FROM parties WHERE ABS(RANDOM() % {REDUCTION_FACTOR}) = 0\", con)"
    ]
   },
   {

--- a/files/interview-prep/Interview Prep Python.ipynb
+++ b/files/interview-prep/Interview Prep Python.ipynb
@@ -47,7 +47,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "REDUCTION_FACTOR = 10"
+    "REDUCTION_FACTOR = 10 \n",
+    "RAND_REMAINDER=int(random.random()*REDUCTION_FACTOR) # a random number no larger than REDUCTION_FACTOR"
    ]
   },
   {
@@ -57,10 +58,12 @@
    "outputs": [],
    "source": [
     "collisions = pd.read_sql(\n",
-    "    f\"SELECT * FROM collisions WHERE ABS(RANDOM() % {REDUCTION_FACTOR}) = 0\", \n",
+    "    f\"SELECT * FROM collisions WHERE case_id%{REDUCTION_FACTOR} = {RAND_REMAINDER}\", \n",
     "    con, \n",
     "    parse_dates=[\"collision_date\"]\n",
-    ")"
+    ")\n",
+    "# the end of case_id values act as decent pseudo uniform random number between 0--REDUCTION_FACTOR \n",
+    "# select case_id values ending in RAND_REMAINDER"
    ]
   },
   {
@@ -69,7 +72,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parties = pd.read_sql(f\"SELECT * FROM parties WHERE ABS(RANDOM() % {REDUCTION_FACTOR}) = 0\", con)"
+    "# select by the same case_id values\n",
+    "parties = pd.read_sql(f\"SELECT * FROM parties WHERE case_id%{REDUCTION_FACTOR} = {RAND_REMAINDER}\", con)"
    ]
   },
   {

--- a/files/interview-prep/Interview Prep Python.ipynb
+++ b/files/interview-prep/Interview Prep Python.ipynb
@@ -7,7 +7,8 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import sqlite3"
+    "import sqlite3\n",
+    "import random"
    ]
   },
   {

--- a/files/interview-prep/Interview Prep Python.ipynb
+++ b/files/interview-prep/Interview Prep Python.ipynb
@@ -7,8 +7,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import sqlite3\n",
-    "import random"
+    "import sqlite3"
    ]
   },
   {

--- a/files/interview-prep/Interview Prep SQL Solutions.ipynb
+++ b/files/interview-prep/Interview Prep SQL Solutions.ipynb
@@ -185,14 +185,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "QUERY2 = \"\"\"\n",
     "SELECT \n",
-    "    COUNT(DISTINCT case_id) \n",
-    "    / (SELECT CAST(COUNT(DISTINCT case_id) AS FLOAT) FROM parties)\n",
+    "    COUNT(case_id) \n",
+    "    / (SELECT \n",
+    "            CAST(COUNT(case_id) AS FLOAT) \n",
+    "        FROM parties \n",
+    "        WHERE party_sex='male' \n",
+    "        OR party_sex='female' \n",
+    "        AND party_age IS NOT NULL)\n",
     "    AS percentage\n",
     "FROM parties\n",
     "WHERE party_sex = 'male'\n",
@@ -202,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "metadata": {
     "scrolled": true
    },
@@ -234,7 +239,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.241562</td>\n",
+       "      <td>0.151478</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -242,10 +247,10 @@
       ],
       "text/plain": [
        "   percentage\n",
-       "0    0.241562"
+       "0    0.151478"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/files/interview-prep/Interview Prep SQL Solutions.ipynb
+++ b/files/interview-prep/Interview Prep SQL Solutions.ipynb
@@ -180,7 +180,9 @@
     "calculate the ratio as this requires us to get the total number of collisions.\n",
     "We could hard-code the number, but I prefer calculating it as part of the\n",
     "query. There isn't a super elegant way to do it in SQLite, but a sub-query\n",
-    "works fine. We also have to cast to a float to avoid integer division."
+    "works fine. A significant portion of the records (more than 10%) have null \n",
+    "for age and sex, assuming the nulls are distributed evenly over age and sex, \n",
+    "they can be excluded from the total number of collisions. We also have to cast to a float to avoid integer division."
    ]
   },
   {

--- a/files/interview-prep/Interview Prep SQL Solutions.ipynb
+++ b/files/interview-prep/Interview Prep SQL Solutions.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -157,7 +157,7 @@
        "0          9172565"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -181,13 +181,13 @@
     "We could hard-code the number, but I prefer calculating it as part of the\n",
     "query. There isn't a super elegant way to do it in SQLite, but a sub-query\n",
     "works fine. A significant portion of the records (more than 10%) have null \n",
-    "for age and sex, assuming the nulls are distributed evenly over age and sex, \n",
-    "they can be excluded from the total number of collisions. We also have to cast to a float to avoid integer division."
+    "for age and sex. Assuming the nulls are distributed evenly over age and sex, \n",
+    "they are excluded from the total number of collisions. We also have to cast to a float to avoid integer division."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 20,
    "metadata": {
     "scrolled": true
    },
@@ -252,7 +252,7 @@
        "0    0.151478"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 22,
    "metadata": {
     "scrolled": false
    },
@@ -457,7 +457,7 @@
        "19           2020             2984"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -503,23 +503,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
     "QUERY41 = \"\"\"\n",
     "SELECT \n",
     "  make,\n",
-    "  weekday_count / CAST(total AS FLOAT) AS weekday_ratio\n",
+    "  weekday_ratio\n",
     "FROM (    \n",
     "  SELECT\n",
     "    p.vehicle_make AS make,\n",
-    "    SUM(\n",
+    "    AVG(\n",
     "      CASE WHEN STRFTIME('%w', c.collision_date) IN ('0', '6') THEN 1 ELSE 0 END\n",
-    "    ) AS weekend_count,\n",
-    "    SUM(\n",
+    "    ) AS weekend_ratio,\n",
+    "    AVG(\n",
     "      CASE WHEN STRFTIME('%w', c.collision_date) IN ('0', '6') THEN 0 ELSE 1 END\n",
-    "    ) AS weekday_count,\n",
+    "    ) AS weekday_ratio,\n",
     "    count(1) AS total\n",
     "  FROM collisions AS c\n",
     "  LEFT JOIN parties AS p\n",
@@ -534,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 29,
    "metadata": {
     "scrolled": true
    },
@@ -579,7 +579,7 @@
        "0  PETERBILT        0.90823"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
- Ratio of male age 16--25 were normalized by total records, but >10% of the records have null for age and sex and I think we should leave them out of the total?
- In `parties`, `case_id` repeats when the collision is not solo. should we not use `DISTINCT` ?
- `AVG()` is slightly less typing than `SUM()/total`? There are a few occasions of this
1 file changed: https://github.com/agude/agude.github.io/blob/master/files/interview-prep/Interview%20Prep%20SQL%20Solutions.ipynb
reverted the two commits belong to  PR https://github.com/agude/agude.github.io/pull/56